### PR TITLE
[AI] #1: Create github action for creating automatic release and github packages for the executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - prod
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Extract version from appsettings.json
+        id: version
+        run: |
+          VERSION=$(cat src/TaskFinisher/appsettings.json | python3 -c "import sys, json; print(json.load(sys.stdin)['App']['Version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Restore dependencies
+        run: dotnet restore task-finisher.sln
+
+      - name: Build
+        run: dotnet build task-finisher.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test task-finisher.sln --configuration Release --no-build --verbosity normal
+
+      - name: Publish - linux-x64
+        run: |
+          dotnet publish src/TaskFinisher/TaskFinisher.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=true \
+            --output ./publish/linux-x64
+
+      - name: Publish - linux-arm64
+        run: |
+          dotnet publish src/TaskFinisher/TaskFinisher.csproj \
+            --configuration Release \
+            --runtime linux-arm64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=true \
+            --output ./publish/linux-arm64
+
+      - name: Publish - win-x64
+        run: |
+          dotnet publish src/TaskFinisher/TaskFinisher.csproj \
+            --configuration Release \
+            --runtime win-x64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=true \
+            --output ./publish/win-x64
+
+      - name: Publish - osx-x64
+        run: |
+          dotnet publish src/TaskFinisher/TaskFinisher.csproj \
+            --configuration Release \
+            --runtime osx-x64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=true \
+            --output ./publish/osx-x64
+
+      - name: Publish - osx-arm64
+        run: |
+          dotnet publish src/TaskFinisher/TaskFinisher.csproj \
+            --configuration Release \
+            --runtime osx-arm64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=true \
+            --output ./publish/osx-arm64
+
+      - name: Package executables
+        run: |
+          cd publish
+          zip -j task-finisher-linux-x64.zip linux-x64/task-finisher
+          zip -j task-finisher-linux-arm64.zip linux-arm64/task-finisher
+          zip -j task-finisher-win-x64.zip win-x64/task-finisher.exe
+          zip -j task-finisher-osx-x64.zip osx-x64/task-finisher
+          zip -j task-finisher-osx-arm64.zip osx-arm64/task-finisher
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body: ${{ github.event.pull_request.body }}
+          files: |
+            publish/task-finisher-linux-x64.zip
+            publish/task-finisher-linux-arm64.zip
+            publish/task-finisher-win-x64.zip
+            publish/task-finisher-osx-x64.zip
+            publish/task-finisher-osx-arm64.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Created a GitHub Actions workflow (`.github/workflows/release.yml`) that automatically builds, tests, packages, and releases the `task-finisher` application whenever a PR is merged into the `prod` branch. The workflow reads the version from `appsettings.json`, publishes self-contained single-file executables for five platforms, zips them, and creates a GitHub Release with the merged PR's description as the release notes.

## Changes Made

- `.github/workflows/release.yml` *(new)*: GitHub Actions workflow that:
  - Triggers only on PRs merged to `prod` branch
  - Extracts the version from `src/TaskFinisher/appsettings.json` (`App.Version` field) using Python3
  - Restores, builds, and tests the full solution (`task-finisher.sln`)
  - Publishes self-contained, trimmed, single-file executables for `linux-x64`, `linux-arm64`, `win-x64`, `osx-x64`, and `osx-arm64` runtimes
  - Packages each platform binary into a `.zip` archive
  - Creates a GitHub Release tagged as `v{version}` with the merged PR body as the release description, attaching all five platform zip files as downloadable assets

## Testing

To verify the workflow:
1. Create a PR targeting the `prod` branch with a meaningful description.
2. Merge the PR — the `Release` workflow will trigger automatically.
3. Confirm the workflow run succeeds in the **Actions** tab of the repository.
4. Check that a new GitHub Release tagged `v1.0.0` (or whatever version is in `appsettings.json`) is created under the **Releases** section.
5. Verify all five platform zip files (`task-finisher-linux-x64.zip`, `task-finisher-linux-arm64.zip`, `task-finisher-win-x64.zip`, `task-finisher-osx-x64.zip`, `task-finisher-osx-arm64.zip`) are attached as release assets.
6. Confirm the release notes match the PR description.