### PR TITLE
[AI] #8: Add a description when asking in the console application how to obtain a Github Token and AI API Key

### DIFF
--- a/src/TaskFinisher/Services/CredentialService.cs
+++ b/src/TaskFinisher/Services/CredentialService.cs
@@ -105,6 +105,21 @@ public sealed class CredentialService : ICredentialService
             && PromptUseSaved("GitHub Token", saved.GitHubToken))
             return saved.GitHubToken;
 
+        var githubPanel = new Panel(
+                "[white]A GitHub Personal Access Token is required to read issues and open Pull Requests.[/]\n\n" +
+                "[silver]To create one:[/]\n" +
+                "  1. Go to [deepskyblue1]https://github.com/settings/tokens[/]\n" +
+                "  2. Click [bold white]Generate new token (classic)[/]\n" +
+                "  3. Give it a name, set an expiry, and tick the [bold white]repo[/] scope\n" +
+                "  4. Click [bold white]Generate token[/] and copy the value below")
+            .Header("[bold deepskyblue1] GitHub Personal Access Token [/]")
+            .BorderColor(Color.SteelBlue1)
+            .Padding(1, 0);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(githubPanel);
+        AnsiConsole.WriteLine();
+
         var token = PromptSecret("GitHub Personal Access Token");
         var e     = LoadSaved();
         SaveAll(token, e?.AnthropicApiKey ?? string.Empty, e?.Model ?? string.Empty);
@@ -125,6 +140,20 @@ public sealed class CredentialService : ICredentialService
         if (!string.IsNullOrWhiteSpace(saved?.AnthropicApiKey)
             && PromptUseSaved("Anthropic API Key", saved.AnthropicApiKey))
             return saved.AnthropicApiKey;
+
+        var anthropicPanel = new Panel(
+                "[white]An Anthropic API Key is required to call the Claude AI model that resolves your issues.[/]\n\n" +
+                "[silver]To create one:[/]\n" +
+                "  1. Go to [deepskyblue1]https://console.anthropic.com/settings/keys[/]\n" +
+                "  2. Sign in or create a free account\n" +
+                "  3. Click [bold white]Create Key[/], give it a name, and copy the value below")
+            .Header("[bold deepskyblue1] Anthropic API Key [/]")
+            .BorderColor(Color.SteelBlue1)
+            .Padding(1, 0);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(anthropicPanel);
+        AnsiConsole.WriteLine();
 
         var key = PromptSecret("Anthropic API Key");
         var e   = LoadSaved();


### PR DESCRIPTION
## Summary

Added descriptive help panels to the console application that are shown when users are prompted to enter their GitHub Personal Access Token and Anthropic API Key for the first time. These panels explain what each credential is used for and provide step-by-step instructions on how to obtain them.

## Changes Made

- **`src/TaskFinisher/Services/CredentialService.cs`**: Added two styled `Panel` components (using the existing Spectre.Console patterns/styles) that are rendered just before the secret-input prompts:
  - **GitHub Token panel**: Explains the token is needed to read issues and open PRs, and walks users through creating a classic Personal Access Token at `https://github.com/settings/tokens` with the `repo` scope.
  - **Anthropic API Key panel**: Explains the key is needed to call the Claude AI model, and walks users through creating a key at `https://console.anthropic.com/settings/keys`. Both panels use the same `SteelBlue1` border colour and `deepskyblue1` header style consistent with the rest of the UI.

## Testing

1. Run the application interactively without any saved credentials or environment variables:
   ```bash
   dotnet run --project src/TaskFinisher -- --reset
   dotnet run --project src/TaskFinisher
   ```
2. When prompted for each credential for the first time, you should see a bordered panel describing what the credential is and how to obtain it, followed by the masked input prompt.
3. All 13 existing unit tests continue to pass: `dotnet test`