### PR TITLE
[AI] #10: Show app version below the author name in the beginning of the app

### DIFF
--- a/src/TaskFinisher/Commands/RunCommand.cs
+++ b/src/TaskFinisher/Commands/RunCommand.cs
@@ -57,6 +57,7 @@ public sealed class RunCommand(
                     new Rule().RuleStyle(Style.Parse("deepskyblue1 dim")),
                     new Markup(
                         "[silver]  by[/] [bold white]Muhammet Tutcugil[/]\n" +
+                        $"  [silver]v{settings.Version}[/]\n" +
                         "  [deepskyblue1]https://www.tutcugil.com[/]\n" +
                         "  [white]AI-powered GitHub issue resolver[/]")))
             .Border(BoxBorder.Double)

--- a/src/TaskFinisher/Configuration/AppSettings.cs
+++ b/src/TaskFinisher/Configuration/AppSettings.cs
@@ -2,6 +2,9 @@ namespace TaskFinisher.Configuration;
 
 public sealed class AppSettings
 {
+    // App metadata
+    public string Version { get; set; } = "0.0.1";
+
     // Credentials - populated at runtime from env vars or interactive prompts; never written to disk
     public string GitHubToken     { get; set; } = string.Empty;
     public string AnthropicApiKey { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary

Added the app version display below the author name in the startup header of the app, as requested in issue #10. The version is sourced from the `AppSettings` class (defaulting to `"0.0.1"` to match `appsettings.json`), and rendered in the header panel using a dim silver style consistent with the existing UI aesthetics.

## Changes Made

- **`src/TaskFinisher/Configuration/AppSettings.cs`**: Added a `Version` property (with default value `"0.0.1"` matching `appsettings.json`) under a new `// App metadata` comment section.
- **`src/TaskFinisher/Commands/RunCommand.cs`**: Updated the startup header panel markup to include `v{settings.Version}` on a new line directly below the author name (`Muhammet Tutcugil`), styled as `[silver]` to match the surrounding dim text style.

## Testing

Run the application normally and observe the startup banner:

```
╔══════════════════════════════╗
║  [task figlet]               ║
║  [finisher figlet]           ║
║  ─────────────────────────── ║
║    by Muhammet Tutcugil       ║
║    v0.0.1                    ║  ← new line
║    https://www.tutcugil.com  ║
║    AI-powered GitHub issue   ║
║    resolver                  ║
╚══════════════════════════════╝
```

The version shown reflects `AppSettings.Version`, which defaults to `"0.0.1"` (aligned with `appsettings.json`).