### PR TITLE
[AI] #15: Give user a option to cancel and return previous menu in the issue selection section

### DIFF
--- a/src/TaskFinisher/Commands/RunCommand.cs
+++ b/src/TaskFinisher/Commands/RunCommand.cs
@@ -230,6 +230,12 @@ public sealed class RunCommand(
 
         // Issue selection
         var selected = IssueSelector.Select(issues);
+        if (selected is null)
+        {
+            // User chose to go back to the previous menu
+            return PromptNavigation(settings.Repository);
+        }
+
         if (selected.Count == 0)
         {
             AnsiConsole.MarkupLine("[silver]No issues selected.[/]");

--- a/src/TaskFinisher/UI/IssueSelector.cs
+++ b/src/TaskFinisher/UI/IssueSelector.cs
@@ -5,23 +5,46 @@ namespace TaskFinisher.UI;
 
 public static class IssueSelector
 {
-    public static IReadOnlyList<DataGitHubIssue> Select(IReadOnlyList<DataGitHubIssue> issues)
+    // Non-null wrapper so MultiSelectionPrompt<T>'s notnull constraint is satisfied
+    private sealed record Choice(DataGitHubIssue? Issue);
+
+    private static readonly Choice BackChoice = new(null);
+
+    /// <summary>
+    /// Shows an interactive issue picker.
+    /// Returns the selected issues, or <c>null</c> if the user chose to go back.
+    /// </summary>
+    public static IReadOnlyList<DataGitHubIssue>? Select(IReadOnlyList<DataGitHubIssue> issues)
     {
         if (issues.Count == 0)
             return [];
 
-        return AnsiConsole.Prompt(
-            new MultiSelectionPrompt<DataGitHubIssue>()
+        var choices = new List<Choice> { BackChoice };
+        choices.AddRange(issues.Select(i => new Choice(i)));
+
+        var selected = AnsiConsole.Prompt(
+            new MultiSelectionPrompt<Choice>()
                 .Title("[bold white]Select issues to process:[/]")
                 .PageSize(15)
                 .MoreChoicesText("[silver](Move up/down to reveal more)[/]")
                 .InstructionsText("[silver]([deepskyblue1]Space[/] to select, [lime]Enter[/] to confirm)[/]")
                 .HighlightStyle(new Style(Color.DeepSkyBlue1, decoration: Decoration.Bold))
-                .UseConverter(i =>
+                .UseConverter(c =>
                 {
-                    var labels = i.Labels.Length > 0 ? $" [silver]({string.Join(", ", i.Labels)})[/]" : "";
-                    return $"[white]#{i.Number}[/] {Markup.Escape(i.Title)}{labels}";
+                    if (c.Issue is null)
+                        return "← Back to previous menu";
+
+                    var labels = c.Issue.Labels.Length > 0
+                        ? $" [silver]({string.Join(", ", c.Issue.Labels)})[/]"
+                        : "";
+                    return $"[white]#{c.Issue.Number}[/] {Markup.Escape(c.Issue.Title)}{labels}";
                 })
-                .AddChoices(issues));
+                .AddChoices(choices));
+
+        // If the user selected the Back option, treat it as a cancellation
+        if (selected.Any(c => c.Issue is null))
+            return null;
+
+        return selected.Select(c => c.Issue!).ToList();
     }
 }


### PR DESCRIPTION
## Summary

Added a "← Back to previous menu" option in the issue selection screen so users can cancel out of the multi-select prompt and return to the navigation menu, instead of being stuck or having to force-quit.

## Changes Made

- **`src/TaskFinisher/UI/IssueSelector.cs`**: Refactored to use a private `Choice` wrapper record (identical pattern to `RepoSelector`) to satisfy `MultiSelectionPrompt<T>`'s `notnull` constraint while still supporting a sentinel "back" entry. A `← Back to previous menu` choice is prepended to the issues list. The method return type changed from `IReadOnlyList<DataGitHubIssue>` to `IReadOnlyList<DataGitHubIssue>?` — returning `null` when the user selects the Back option.

- **`src/TaskFinisher/Commands/RunCommand.cs`**: Updated `RunRepoSessionAsync` to handle the new nullable return from `IssueSelector.Select`. When `null` is returned (user chose Back), it immediately falls through to `PromptNavigation` so the user can choose to process more issues, switch repository, or exit.

## Testing

1. Run `task-finisher` interactively
2. Select a repository with open issues
3. Choose "Browse and process issues"
4. In the issue selection prompt, select the **"← Back to previous menu"** entry (using Space) and press Enter
5. Verify that the "What would you like to do next?" navigation menu is displayed instead of proceeding to process issues