### PR TITLE
[AI] #18: Update app version from 0.0.1 to 0.0.2

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "configurations": [
     {
       "name": "task-finisher (run)",

--- a/src/TaskFinisher/Configuration/AppSettings.cs
+++ b/src/TaskFinisher/Configuration/AppSettings.cs
@@ -3,7 +3,7 @@ namespace TaskFinisher.Configuration;
 public sealed class AppSettings
 {
     // App metadata
-    public string Version { get; set; } = "0.0.1";
+    public string Version { get; set; } = "0.0.2";
 
     // Credentials - populated at runtime from env vars or interactive prompts; never written to disk
     public string GitHubToken     { get; set; } = string.Empty;

--- a/src/TaskFinisher/appsettings.json
+++ b/src/TaskFinisher/appsettings.json
@@ -2,7 +2,7 @@
   "App": {
     "Project": "tutcugil",
     "Name": "task-finisher",
-    "Version": "0.0.1",
+    "Version": "0.0.2",
     "Operation": "ALFA"
   },
   "AppSettings": {


### PR DESCRIPTION
## Summary
Updated the application version from `0.0.1` to `0.0.2` across all relevant source files as requested in issue #18.

## Changes Made
- **`src/TaskFinisher/appsettings.json`**: Updated `"Version"` field from `"0.0.1"` to `"0.0.2"`
- **`src/TaskFinisher/Configuration/AppSettings.cs`**: Updated default value of the `Version` property from `"0.0.1"` to `"0.0.2"`
- **`.claude/launch.json`**: Updated the top-level `"version"` field from `"0.0.1"` to `"0.0.2"`

## Testing
1. Build the project: `dotnet build src/TaskFinisher/TaskFinisher.csproj`
2. Run the application and verify the version reported is `0.0.2`
3. Confirm `AppSettings.Version` resolves to `"0.0.2"` at runtime (the value is sourced from `appsettings.json` and falls back to the default in `AppSettings.cs`)