### PR TITLE
[AI] #21: Add show all other repositories option to repository selection menu

### DIFF
--- a/src/TaskFinisher/Commands/RunCommand.cs
+++ b/src/TaskFinisher/Commands/RunCommand.cs
@@ -176,16 +176,42 @@ public sealed class RunCommand(
                     });
 
                 var reposWithIssues = repos.Where(r => r.OpenIssuesCount > 0).ToList();
+                var hasOtherRepos   = repos.Count > reposWithIssues.Count;
 
                 if (reposWithIssues.Count == 0)
                 {
                     AnsiConsole.MarkupLine("[yellow]No repositories with open issues found on your account.[/]");
-                    return null;
+
+                    if (repos.Count == 0)
+                        return null;
+
+                    // Offer to show all repos even though none have open issues
+                    AnsiConsole.MarkupLine($"[silver]{repos.Count} repositor{(repos.Count == 1 ? "y" : "ies")} available in total.[/]");
+                    var result = RepoSelector.Select(repos, showAllOption: false);
+                    return result.ResultKind == RepoSelectionResult.Kind.Selected
+                        ? result.FullName
+                        : null;
                 }
 
                 AnsiConsole.MarkupLine($"[silver]{reposWithIssues.Count} repositor{(reposWithIssues.Count == 1 ? "y" : "ies")} with open issues found.[/]");
-                var picked = RepoSelector.Select(reposWithIssues);
-                return picked?.FullName; // null = user chose Exit
+
+                while (true) // inner loop to handle "show all" selection
+                {
+                    var result = RepoSelector.Select(reposWithIssues, showAllOption: hasOtherRepos);
+
+                    if (result.ResultKind == RepoSelectionResult.Kind.Selected)
+                        return result.FullName;
+
+                    if (result.ResultKind == RepoSelectionResult.Kind.Exit)
+                        return null;
+
+                    // ShowAll — display the full repository list (no "show all" option this time)
+                    AnsiConsole.MarkupLine($"[silver]{repos.Count} repositor{(repos.Count == 1 ? "y" : "ies")} total.[/]");
+                    var allResult = RepoSelector.Select(repos, showAllOption: false);
+                    return allResult.ResultKind == RepoSelectionResult.Kind.Selected
+                        ? allResult.FullName
+                        : null;
+                }
             }
             catch (AuthorizationException)
             {

--- a/src/TaskFinisher/UI/RepoSelector.cs
+++ b/src/TaskFinisher/UI/RepoSelector.cs
@@ -6,18 +6,27 @@ namespace TaskFinisher.UI;
 public static class RepoSelector
 {
     // Non-null wrapper so SelectionPrompt<T>'s notnull constraint is satisfied
-    private sealed record Choice(DataGitHubRepo? Repo);
+    private sealed record Choice(DataGitHubRepo? Repo, bool ShowAll = false);
 
-    private static readonly Choice ExitChoice = new(null);
+    private static readonly Choice ExitChoice    = new(null, ShowAll: false);
+    private static readonly Choice ShowAllChoice = new(null, ShowAll: true);
 
     /// <summary>
     /// Shows an interactive repository picker.
-    /// Returns the selected repo, or <c>null</c> if the user chose to exit.
+    /// Returns the selected repo's full name, or <c>null</c> if the user chose to exit.
+    /// When <paramref name="showAllOption"/> is <c>true</c> an extra
+    /// "Show all other repositories" entry is appended; if chosen, the method
+    /// returns <see cref="ShowAllRepositories"/> so the caller can re-invoke
+    /// with the complete list.
     /// </summary>
-    public static DataGitHubRepo? Select(IReadOnlyList<DataGitHubRepo> repos)
+    public static RepoSelectionResult Select(
+        IReadOnlyList<DataGitHubRepo> repos,
+        bool showAllOption = false)
     {
         var choices = new List<Choice> { ExitChoice };
         choices.AddRange(repos.Select(r => new Choice(r)));
+        if (showAllOption)
+            choices.Add(ShowAllChoice);
 
         AnsiConsole.WriteLine();
 
@@ -27,11 +36,21 @@ public static class RepoSelector
                 .PageSize(18)
                 .MoreChoicesText("[silver](↑↓ to reveal more)[/]")
                 .HighlightStyle(new Style(Color.DeepSkyBlue1, decoration: Decoration.Bold))
-                .UseConverter(c => c.Repo is null ? "✕  Exit" : FormatRepo(c.Repo))
+                .UseConverter(c =>
+                {
+                    if (c.ShowAll) return "☰  Show all other repositories";
+                    return c.Repo is null ? "✕  Exit" : FormatRepo(c.Repo);
+                })
                 .AddChoices(choices));
 
         AnsiConsole.WriteLine();
-        return chosen.Repo; // null = user chose Exit
+
+        if (chosen.ShowAll)
+            return RepoSelectionResult.ShowAllRepositories;
+
+        return chosen.Repo is null
+            ? RepoSelectionResult.Exit
+            : RepoSelectionResult.Selected(chosen.Repo.FullName);
     }
 
     private static string FormatRepo(DataGitHubRepo r)
@@ -48,4 +67,25 @@ public static class RepoSelector
 
         return $"[white]{Markup.Escape(r.FullName)}[/]{privacy}{issues}{desc}";
     }
+}
+
+/// <summary>Outcome of <see cref="RepoSelector.Select"/>.</summary>
+public sealed class RepoSelectionResult
+{
+    public enum Kind { Selected, Exit, ShowAll }
+
+    public Kind         ResultKind { get; }
+    public string?      FullName   { get; }
+
+    private RepoSelectionResult(Kind kind, string? fullName = null)
+    {
+        ResultKind = kind;
+        FullName   = fullName;
+    }
+
+    public static readonly RepoSelectionResult Exit                = new(Kind.Exit);
+    public static readonly RepoSelectionResult ShowAllRepositories = new(Kind.ShowAll);
+
+    public static RepoSelectionResult Selected(string fullName) =>
+        new(Kind.Selected, fullName);
 }


### PR DESCRIPTION
## Summary

Added a "Show all other repositories" option to the repository selection menu. Previously, the picker only showed repositories that had open issues; users had no way to select a repository without open issues (e.g. to create a new issue there). Now, when the full repo list contains repositories beyond those with open issues, an extra **"☰  Show all other repositories"** entry appears at the bottom of the filtered list. Selecting it re-displays the picker with all repositories (including those with no open issues).

## Changes Made

- **`src/TaskFinisher/UI/RepoSelector.cs`**:
  - Added a `ShowAllChoice` sentinel `Choice` (with `ShowAll = true`) and a new `showAllOption` parameter to `Select`.
  - Changed the return type from `DataGitHubRepo?` to the new `RepoSelectionResult` discriminated-union class (`Kind.Selected`, `Kind.Exit`, `Kind.ShowAll`), keeping call-sites clean.
  - Added `☰  Show all other repositories` as the last menu entry when `showAllOption: true`.
  - Added `RepoSelectionResult` sealed class (in the same file) with `Exit`, `ShowAllRepositories` singletons and a `Selected(string)` factory.

- **`src/TaskFinisher/Commands/RunCommand.cs`** (`PickRepoAsync`):
  - Tracks whether there are repositories beyond the with-issues filtered list (`hasOtherRepos`).
  - Passes `showAllOption: hasOtherRepos` to `RepoSelector.Select` so the extra option only appears when relevant.
  - Handles the new `RepoSelectionResult.Kind.ShowAll` outcome by re-invoking `RepoSelector.Select` with the full unfiltered list.
  - Gracefully handles the edge case where *no* repos have open issues but repos exist: shows all repos directly.

## Testing

1. Run the tool interactively (`dotnet run --project src/TaskFinisher`) with a GitHub token that has access to repositories.
2. In the repository selection menu you should see a filtered list of repos with open issues.
3. At the bottom of the list an entry **"☰  Show all other repositories"** appears (only when there are repos without open issues).
4. Selecting it re-displays the picker showing every repository, including those with no open issues.
5. Selecting any repo from either list proceeds normally to the issue workflow.
6. All 13 existing unit tests continue to pass (`dotnet test`).